### PR TITLE
Update transducer-loss.h

### DIFF
--- a/optimized_transducer/csrc/transducer-loss.h
+++ b/optimized_transducer/csrc/transducer-loss.h
@@ -14,7 +14,7 @@ namespace ot {
                  \sum_i (T_i * U_i), where `T_i` is the logit_lengths[i] and
                  `U_i` is `target_lengths[i]` + 1. V is the vocabulary size
                  including the blank.
-  @param targets A 2-D tensor of shape (N, U-1), where N is the batch size.
+  @param targets A 2-D tensor of shape (N, U), where N is the batch size.
   @param logit_lengths A 1-D tensor of shape (N, ) containing number of output
                        acoustic frames from the encoder.
   @param target_lengths A 1-D tensor of shape (N, ) containing the input

--- a/optimized_transducer/csrc/transducer-loss.h
+++ b/optimized_transducer/csrc/transducer-loss.h
@@ -14,7 +14,7 @@ namespace ot {
                  \sum_i (T_i * U_i), where `T_i` is the logit_lengths[i] and
                  `U_i` is `target_lengths[i]` + 1. V is the vocabulary size
                  including the blank.
-  @param targets A 1-D tensor of shape (N, ), where N is the batch size.
+  @param targets A 2-D tensor of shape (N, U-1), where N is the batch size.
   @param logit_lengths A 1-D tensor of shape (N, ) containing number of output
                        acoustic frames from the encoder.
   @param target_lengths A 1-D tensor of shape (N, ) containing the input


### PR DESCRIPTION
I found that `https://github.com/csukuangfj/optimized_transducer/blob/0c75a5712f709024165fe62360dd25905cca8c68/optimized_transducer/csrc/transducer-loss.h#L17 `
and  `https://github.com/csukuangfj/optimized_transducer/blob/0c75a5712f709024165fe62360dd25905cca8c68/optimized_transducer/python/tests/test_compute_transducer_loss.py#L61 `  were not Inconsistent. I think that the front was not correct. Here I fixed it.
@csukuangfj , what do you think?