### PR TITLE
fix for CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 set(languages CXX)
 set(_OT_WITH_CUDA ON)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_program(OT_HAS_NVCC nvcc)
 if(NOT OT_HAS_NVCC AND "$ENV{CUDACXX}" STREQUAL "")
   message(STATUS "No NVCC detected. Disable CUDA support")


### PR DESCRIPTION
When I run `make -j` in the `build` dir, there is an error happens:
`error: #error C++14 or later compatible compiler is required to use ATen.`.
So I add the following two commands to CMakeLists.txt and the `make -j` process can run successfully.
```
set(CMAKE_CXX_STANDARD 14)
set(CMAKE_CXX_STANDARD_REQUIRED ON)
```
I'm not sure if the above two commands are necesary for the CMakeLists.txt in all environments.